### PR TITLE
Migrate package to null-safety

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -7,7 +7,7 @@ void main() async {
       user: "anonymous", pass: "anonymous", debug: true);
 
   ///an auxiliary function that manage showed log to UI
-  Future<void> _log(String log) async {
+  Future<void> _log(String? log) async {
     print(log ?? '');
     await Future.delayed(Duration(seconds: 1));
   }

--- a/lib/src/commands/file.dart
+++ b/lib/src/commands/file.dart
@@ -1,20 +1,22 @@
+import 'dart:async';
+
 import 'package:ftpconnect/ftpconnect.dart';
 import 'package:ftpconnect/src/util/transferUtil.dart';
 
 import '../ftpSocket.dart';
 
 class FTPFile {
-  FTPSocket _socket;
+  FTPSocket? _socket;
 
   FTPFile(this._socket);
 
   Future<bool> rename(String sOldName, String sNewName) async {
-    String sResponse = await _socket.sendCommand('RNFR $sOldName');
+    String sResponse = await (_socket!.sendCommand('RNFR $sOldName'));
     if (!sResponse.startsWith('350')) {
       return false;
     }
 
-    sResponse = await _socket.sendCommand('RNTO $sNewName');
+    sResponse = await (_socket!.sendCommand('RNTO $sNewName'));
     if (!sResponse.startsWith('250')) {
       return false;
     }
@@ -22,8 +24,8 @@ class FTPFile {
     return true;
   }
 
-  Future<bool> delete(String sFilename) async {
-    String sResponse = await _socket.sendCommand('DELE $sFilename');
+  Future<bool> delete(String? sFilename) async {
+    String sResponse = await (_socket!.sendCommand('DELE $sFilename'));
 
     return sResponse.startsWith('250');
   }
@@ -32,14 +34,14 @@ class FTPFile {
     return await size(sFilename) != -1;
   }
 
-  Future<int> size(String sFilename) async {
+  Future<int> size(String? sFilename) async {
     try {
-      String sResponse = await _socket.sendCommand('SIZE $sFilename');
+      String sResponse = await (_socket!.sendCommand('SIZE $sFilename'));
       if (sResponse.startsWith('550')) {
         //check if ascii mode get refused
         //change to binary mode if ascii mode refused
         await TransferUtil.setTransferMode(_socket, TransferMode.binary);
-        sResponse = await _socket.sendCommand('SIZE $sFilename');
+        sResponse = await (_socket!.sendCommand('SIZE $sFilename'));
         //back to ascci mode
         await TransferUtil.setTransferMode(_socket, TransferMode.ascii);
       }

--- a/lib/src/commands/fileDownload.dart
+++ b/lib/src/commands/fileDownload.dart
@@ -11,15 +11,15 @@ import 'file.dart';
 typedef void FileProgress(double progress, int totalLength);
 
 class FileDownload {
-  final FTPSocket _socket;
+  final FTPSocket? _socket;
   final TransferMode _mode;
   final DebugLog _log;
 
   /// File Download Command
   FileDownload(this._socket, this._mode, this._log);
 
-  Future<bool> downloadFile(String sRemoteName, File fLocalFile,
-      {FileProgress onProgress}) async {
+  Future<bool> downloadFile(String? sRemoteName, File fLocalFile,
+      {FileProgress? onProgress}) async {
     _log.log('Download $sRemoteName to ${fLocalFile.path}');
     //check for file existence and init totalData to receive
     int fileSize = 0;
@@ -32,18 +32,18 @@ class FileDownload {
     await TransferUtil.setTransferMode(_socket, _mode);
 
     // Enter passive mode
-    String sResponse = await TransferUtil.enterPassiveMode(_socket);
+    String sResponse = await TransferUtil.enterPassiveMode(_socket!);
 
     //the response will be the file, witch will be loaded with another socket
-    await _socket.sendCommand('RETR $sRemoteName', waitResponse: false);
+    await _socket!.sendCommand('RETR $sRemoteName', waitResponse: false);
 
     // Data Transfer Socket
-    int iPort = TransferUtil.parsePort(sResponse);
+    int iPort = TransferUtil.parsePort(sResponse)!;
     _log.log('Opening DataSocket to Port $iPort');
-    final Socket dataSocket = await Socket.connect(_socket.host, iPort,
-        timeout: Duration(seconds: _socket.timeout));
+    final Socket dataSocket = await Socket.connect(_socket!.host, iPort,
+        timeout: Duration(seconds: _socket!.timeout));
     // Test if second socket connection accepted or not
-    sResponse = await TransferUtil.checkIsConnectionAccepted(_socket);
+    sResponse = await TransferUtil.checkIsConnectionAccepted(_socket!);
 
     // Changed to listen mode instead so that it's possible to send information back on downloaded amount
     var sink = fLocalFile.openWrite(mode: FileMode.writeOnly);

--- a/lib/src/commands/fileUpload.dart
+++ b/lib/src/commands/fileUpload.dart
@@ -9,7 +9,7 @@ import '../util/transferUtil.dart';
 import 'fileDownload.dart';
 
 class FileUpload {
-  final FTPSocket _socket;
+  final FTPSocket? _socket;
   final TransferMode _mode;
   final DebugLog _log;
 
@@ -18,30 +18,30 @@ class FileUpload {
 
   /// Upload File [fFile] to the current directory with [remoteName] (using filename if not set)
   Future<bool> uploadFile(File fFile,
-      {String remoteName = '', FileProgress onProgress}) async {
+      {String remoteName = '', FileProgress? onProgress}) async {
     _log.log('Upload File: ${fFile.path}');
 
     // Transfer Mode
     await TransferUtil.setTransferMode(_socket, _mode);
 
     // Enter passive mode
-    String sResponse = await TransferUtil.enterPassiveMode(_socket);
+    String sResponse = await TransferUtil.enterPassiveMode(_socket!);
 
     // Store File
     String sFilename = remoteName;
-    if (sFilename == null || sFilename.isEmpty) {
+    if (sFilename.isEmpty) {
       sFilename = basename(fFile.path);
     }
 
     // The response is the file to upload, witch will be managed by another socket
-    await _socket.sendCommand('STOR $sFilename', waitResponse: false);
+    await _socket!.sendCommand('STOR $sFilename', waitResponse: false);
 
     // Data Transfer Socket
-    int iPort = TransferUtil.parsePort(sResponse);
+    int iPort = TransferUtil.parsePort(sResponse)!;
     _log.log('Opening DataSocket to Port $iPort');
-    final Socket dataSocket = await Socket.connect(_socket.host, iPort);
+    final Socket dataSocket = await Socket.connect(_socket!.host, iPort);
     //Test if second socket connection accepted or not
-    sResponse = await TransferUtil.checkIsConnectionAccepted(_socket);
+    sResponse = await TransferUtil.checkIsConnectionAccepted(_socket!);
 
     _log.log('Start uploading...');
     final readStream = fFile.openRead();

--- a/lib/src/ftpExceptions.dart
+++ b/lib/src/ftpExceptions.dart
@@ -1,6 +1,6 @@
 class FTPException implements Exception {
   final String message;
-  final String response;
+  final String? response;
 
   FTPException(this.message, [this.response]);
 

--- a/lib/src/ftpSocket.dart
+++ b/lib/src/ftpSocket.dart
@@ -12,7 +12,7 @@ class FTPSocket {
   final DebugLog _log;
   final int timeout;
 
-  RawSocket _socket;
+  RawSocket? _socket;
 
   FTPSocket(this.host, this.port, this._log, this.timeout);
 
@@ -20,10 +20,10 @@ class FTPSocket {
   ///
   /// Blocks until data is received!
   Future<String> readResponse() async {
-    String sResponse;
+    late String sResponse;
     await Future.doWhile(() async {
-      if (_socket.available() > 0) {
-        sResponse = String.fromCharCodes(_socket.read()).trim();
+      if (_socket!.available() > 0) {
+        sResponse = String.fromCharCodes(_socket!.read()!).trim();
         return false;
       }
       await Future.delayed(Duration(milliseconds: 200));
@@ -40,7 +40,7 @@ class FTPSocket {
   /// if [waitResponse] the function waits for the reply, other wise return ''
   Future<String> sendCommand(String cmd, {bool waitResponse = true}) async {
     _log.log('> $cmd');
-    _socket.write(Utf8Codec().encode('$cmd\r\n'));
+    _socket!.write(Utf8Codec().encode('$cmd\r\n'));
 
     if (waitResponse == true) {
       var res = await readResponse();
@@ -52,7 +52,7 @@ class FTPSocket {
   ///if we receive a response different then that we are waiting for
   ///(both success or fail), we read again the response
   Future<bool> _isResponseOK(
-      String response, List<int> successCode, List<int> failCode) async {
+      String? response, List<int> successCode, List<int> failCode) async {
     if (TransferUtil.isResponseStartsWith(response, failCode)) return false;
     if (!TransferUtil.isResponseStartsWith(response, successCode)) {
       response = await readResponse();
@@ -71,12 +71,11 @@ class FTPSocket {
       _socket = await RawSocket.connect(host, port,
           timeout: Duration(seconds: timeout));
     } catch (e) {
-      throw FTPException(
-          'Could not connect to $host ($port)', e?.toString() ?? '');
+      throw FTPException('Could not connect to $host ($port)', e.toString());
     }
 
     // Send Username
-    String sResponse = await sendCommand('USER $user');
+    String? sResponse = await sendCommand('USER $user');
     if (!await _isResponseOK(sResponse, [220, 331], [520])) {
       throw FTPException('Wrong username $user', sResponse);
     }

--- a/lib/src/ftpclient_base.dart
+++ b/lib/src/ftpclient_base.dart
@@ -18,7 +18,7 @@ import 'ftpSocket.dart';
 class FTPConnect {
   final String _user;
   final String _pass;
-  FTPSocket _socket;
+  late FTPSocket _socket;
   final DebugLog _log;
 
   /// Create a FTP Client instance
@@ -53,14 +53,14 @@ class FTPConnect {
   Future<bool> uploadFile(File fFile,
       {String sRemoteName = '',
       TransferMode mode = TransferMode.binary,
-      FileProgress onProgress}) {
+      FileProgress? onProgress}) {
     return FileUpload(_socket, mode, _log)
         .uploadFile(fFile, remoteName: sRemoteName, onProgress: onProgress);
   }
 
   /// Download the Remote File [sRemoteName] to the local File [fFile]
-  Future<bool> downloadFile(String sRemoteName, File fFile,
-      {TransferMode mode = TransferMode.binary, FileProgress onProgress}) {
+  Future<bool> downloadFile(String? sRemoteName, File fFile,
+      {TransferMode mode = TransferMode.binary, FileProgress? onProgress}) {
     return FileDownload(_socket, mode, _log)
         .downloadFile(sRemoteName, fFile, onProgress: onProgress);
   }
@@ -77,7 +77,7 @@ class FTPConnect {
   ///
   /// Returns `true` if the directory was deleted successfully
   /// Returns `false` if the directory could not be deleted or does not nexist
-  Future<bool> deleteEmptyDirectory(String sDirectory) {
+  Future<bool> deleteEmptyDirectory(String? sDirectory) {
     return FTPDirectory(_socket).deleteEmptyDirectory(sDirectory);
   }
 
@@ -86,7 +86,7 @@ class FTPConnect {
   /// Returns `true` if the directory was deleted successfully
   /// Returns `false` if the directory could not be deleted or does not nexist
   /// THIS USEFUL TO DELETE NON EMPTY DIRECTORY
-  Future<bool> deleteDirectory(String sDirectory,
+  Future<bool> deleteDirectory(String? sDirectory,
       {DIR_LIST_COMMAND cmd = DIR_LIST_COMMAND.MLSD}) async {
     String currentDir = await this.currentDirectory();
     if (!await this.changeDirectory(sDirectory)) {
@@ -113,7 +113,7 @@ class FTPConnect {
   /// Use `..` to navigate back
   /// Returns `true` if the directory was changed successfully
   /// Returns `false` if the directory could not be changed (does not exist, no permissions or another error)
-  Future<bool> changeDirectory(String sDirectory) {
+  Future<bool> changeDirectory(String? sDirectory) {
     return FTPDirectory(_socket).changeDirectory(sDirectory);
   }
 
@@ -125,7 +125,7 @@ class FTPConnect {
   /// Returns the content of the current directory
   /// [cmd] refer to the used command for the server, there is servers working
   /// with MLSD and other with LIST
-  Future<List<FTPEntry>> listDirectoryContent({DIR_LIST_COMMAND cmd}) {
+  Future<List<FTPEntry>> listDirectoryContent({DIR_LIST_COMMAND? cmd}) {
     return FTPDirectory(_socket).listDirectoryContent(cmd: cmd);
   }
 
@@ -142,7 +142,7 @@ class FTPConnect {
   }
 
   /// Delete the file [sFilename] from the server
-  Future<bool> deleteFile(String sFilename) {
+  Future<bool> deleteFile(String? sFilename) {
     return FTPFile(_socket).delete(sFilename);
   }
 
@@ -193,8 +193,8 @@ class FTPConnect {
   /// Download the Remote Directory [pRemoteDir] to the local File [pLocalDir]
   /// [pRetryCount] number of attempts
   Future<bool> downloadDirectory(String pRemoteDir, Directory pLocalDir,
-      {DIR_LIST_COMMAND cmd, int pRetryCount = 1}) {
-    Future<bool> downloadDir(String pRemoteDir, Directory pLocalDir) async {
+      {DIR_LIST_COMMAND? cmd, int pRetryCount = 1}) {
+    Future<bool> downloadDir(String? pRemoteDir, Directory pLocalDir) async {
       await pLocalDir.create(recursive: true);
 
       //read remote directory content
@@ -273,10 +273,9 @@ class FTPConnect {
   static Future<List<String>> unZipFile(File zipFile, String destinationPath,
       {password}) async {
     //path should ends with '/'
-    if (destinationPath != null && !destinationPath.endsWith('/'))
-      destinationPath += '/';
+    if (!destinationPath.endsWith('/')) destinationPath += '/';
     //list that will be returned with extracted paths
-    final List<String> lPaths = List();
+    final List<String> lPaths = [];
 
     // Read the Zip file from disk.
     final bytes = await zipFile.readAsBytes();

--- a/lib/src/util/extenstion.dart
+++ b/lib/src/util/extenstion.dart
@@ -5,7 +5,7 @@ extension CommandListTypeEnum on DIR_LIST_COMMAND {
       this.toString().substring(this.toString().indexOf('.') + 1);
 }
 
-extension FtpEntryTypeEnum on FTPEntryType {
+extension FtpEntryTypeEnum on FTPEntryType? {
   String get describeEnum =>
       this.toString().substring(this.toString().indexOf('.') + 1);
 }

--- a/lib/src/util/transferUtil.dart
+++ b/lib/src/util/transferUtil.dart
@@ -7,15 +7,15 @@ import '../ftpSocket.dart';
 class TransferUtil {
   /// Set the Transfer mode on [socket] to [mode]
   static Future<void> setTransferMode(
-      FTPSocket socket, TransferMode mode) async {
+      FTPSocket? socket, TransferMode mode) async {
     switch (mode) {
       case TransferMode.ascii:
         // Set to ASCII mode
-        await socket.sendCommand('TYPE A');
+        await socket!.sendCommand('TYPE A');
         break;
       case TransferMode.binary:
         // Set to BINARY mode
-        await socket.sendCommand('TYPE I');
+        await socket!.sendCommand('TYPE I');
         break;
       default:
         break;
@@ -24,7 +24,7 @@ class TransferUtil {
 
   /// Parse the Passive Mode Port from the Servers [sResponse]
   /// port format (|||xxxxx|)
-  static int parsePort(String sResponse) {
+  static int? parsePort(String sResponse) {
     int iParOpen = sResponse.indexOf('(');
     int iParClose = sResponse.indexOf(')');
 
@@ -60,7 +60,7 @@ class TransferUtil {
   ///original socket [socket], So here we test if the connection to the primary
   ///socket [socket] is accepted or not, if not we throw an exception.
   static Future<String> checkIsConnectionAccepted(FTPSocket socket) async {
-    String sResponse = await socket.readResponse();
+    String sResponse = await (socket.readResponse() as FutureOr<String>);
     if (!sResponse.startsWith('150')) {
       throw FTPException('Connection refused. ', sResponse);
     }
@@ -71,9 +71,9 @@ class TransferUtil {
   ///the secondary socket in the passive mode.
   ///Test first if the response already sent in the previous reply [pResponse]
   ///other wise read again socket [socket] response.
-  static Future<String> checkTransferOK(FTPSocket socket, pResponse) async {
+  static Future<String> checkTransferOK(FTPSocket? socket, pResponse) async {
     if (!pResponse.contains('226')) {
-      pResponse = await socket.readResponse();
+      pResponse = await socket!.readResponse();
       if (!pResponse.startsWith('226')) {
         throw FTPException('Transfer Error.', pResponse);
       }
@@ -82,7 +82,7 @@ class TransferUtil {
   }
 
   ///check the existence of given code inside a a given response
-  static bool isResponseStartsWith(String response, List<int> codes) {
+  static bool isResponseStartsWith(String? response, List<int> codes) {
     var lines = response?.split('\n') ?? [];
     for (var l in lines) {
       for (var c in codes) {
@@ -94,7 +94,7 @@ class TransferUtil {
 
   ///Tell the socket [socket] that we will enter in passive mode
   static Future<String> enterPassiveMode(FTPSocket socket) async {
-    String sResponse = await socket.sendCommand('EPSV');
+    String sResponse = await (socket.sendCommand('EPSV'));
     if (!sResponse.startsWith('229')) {
       throw FTPException('Could not start Passive Mode', sResponse);
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,19 +1,19 @@
 name: ftpconnect
 description: Flutter simple and robust dart FTP Connect Library to interact with FTP Servers with possibility of zip and unzip files.
-version: 0.2.1
+version: 1.0.0
 #author: Salim Lachdhaf
 homepage: https://github.com/salim-lachdhaf
 git: https://github.com/salim-lachdhaf/ftpConnect
 repository: https://github.com/salim-lachdhaf/ftpConnect
 
 environment:
-  sdk: ">=2.6.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  archive: ^2.0.13
-  path: ^1.7.0
-  intl: ^0.16.1
+  archive: ^3.1.2
+  path: ^1.8.0
+  intl: ^0.17.0
 
 dev_dependencies:
-  coverage: ^0.14.2
-  test: ^1.15.7
+  coverage: ^1.0.2
+  test: ^1.16.8

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ftpconnect
 description: Flutter simple and robust dart FTP Connect Library to interact with FTP Servers with possibility of zip and unzip files.
-version: 1.0.0
+version: 1.0.1
 #author: Salim Lachdhaf
 homepage: https://github.com/salim-lachdhaf
 git: https://github.com/salim-lachdhaf/ftpConnect

--- a/test/ftpConnect_test.dart
+++ b/test/ftpConnect_test.dart
@@ -158,7 +158,9 @@ void main() async {
     } catch (e) {
       expect(e is FTPException, equals(true));
       expect(
-          e.message == 'Remote File $remoteFile does not exist!', equals(true));
+          (e as FTPException).message ==
+              'Remote File $remoteFile does not exist!',
+          equals(true));
     }
     //get file size
     expect(await _ftpConnect.sizeFile('../512KB.zip'), equals(512 * 1024));


### PR DESCRIPTION
Since I had some time to spare, I migrated the package to null-safety. Important things to notice:
 * The version number is now `1.0.0`, because Dart recommends setting the first null-safe version to the next major version (even for packages that were before a `1.0.0` version).
 * All the tests seem to pass, but remember that I only looked a few dozens of minutes to the source code of this package, so it might be a good idea to review this pull request carefully.